### PR TITLE
Change current includes to disply name intead of UID

### DIFF
--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -278,7 +278,8 @@ static class Main {
                                                     EntityPartStorage.SavePerSaveSettings();
                                                 }
                                             }
-                                            GUILayout.Label($"    {pair1.Item2}");
+                                            GUILayout.Label($"    {pair1.Item2}", GUILayout.ExpandWidth(false));
+                                            GUILayout.TextArea($"    {pair1.Item1}", GUILayout.ExpandWidth(false));
                                         }
                                     });
                                     GUILayout.Label("------------------------------------------");
@@ -296,6 +297,7 @@ static class Main {
                                                 }
                                                 string itemName = settings.AssetIds.Where(t => t.Item1 == eeName).Select(t => t.Item2).FirstOrDefault();
                                                 GUILayout.Label($"    {itemName}", GUILayout.ExpandWidth(false));
+                                                GUILayout.TextArea($"    {eeName}", GUILayout.ExpandWidth(false));
                                             }
                                         }
                                     }

--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -294,7 +294,8 @@ static class Main {
                                                     EntityPartStorage.perSave.IncludeByName[pickedUnit.UniqueId] = tmpIncludes;
                                                     EntityPartStorage.SavePerSaveSettings();
                                                 }
-                                                GUILayout.TextArea($"    {eeName}", GUILayout.ExpandWidth(false));
+                                                string itemName = settings.AssetIds.Where(t => t.Item1 == eeName).Select(t => t.Item2).FirstOrDefault();
+                                                GUILayout.Label($"    {itemName}", GUILayout.ExpandWidth(false));
                                             }
                                         }
                                     }


### PR DESCRIPTION
The use of UID's in the current includes section makes it difficult to know which items to select when you want to remove one. This change does a lookup of the name by UID and places that value adjacent to the remove include button instead. Also changed it from a textbox to a label to match the exclude section.