### PR TITLE
Fix out of bounds error on lowered grid size

### DIFF
--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -513,7 +513,9 @@ static class Main {
             changedSize |= IntTextField(ref width, GUILayout.MinWidth(60), GUILayout.ExpandWidth(false));
         }
         if (changedSize) {
-            customColorIndex = Math.Max(customColorIndex, height * width - 1);
+            height = Math.Max(1, height);
+            width = Math.Max(1, width);
+            customColorIndex = Math.Min(customColorIndex, height * width - 1);
         }
         using (new GUILayout.HorizontalScope()) {
             bool changed = false;


### PR DESCRIPTION
If you change the height or width of a custom color grid to a lower number, redress crashes and it is difficult to ever recover that character's state. Problem was a Math.Max being used rather than a Math.Min to keep the index equal to the lower value in the field. Also added positive value constraint. 