### PR TITLE
Places equipped grear in excludes automatically when toggle is set.

### DIFF
--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -53,7 +53,6 @@ static class Main {
         modEntry.OnSaveGUI = OnSaveGUI;
         modEntry.OnShowGUI = OnShowGUI;
         settings = Settings.Load<Settings>(modEntry);
-        excludeNewEESave = settings.ShouldExcludeNewEEs;
         HarmonyInstance = new Harmony(modEntry.Info.Id);
         HarmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
         return true;

--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -40,6 +40,7 @@ static class Main {
     internal static UnityModManager.ModEntry.ModLogger log;
     internal static bool isInRoom = false;
     internal static bool doExcludeNewEEs = false;
+    internal static bool isWindowOpen = false;
     public static Settings settings;
     static bool Load(UnityModManager.ModEntry modEntry) {
         log = modEntry.Logger;
@@ -106,10 +107,10 @@ static class Main {
         openedColorSection = false;
         colorPickerItem = "";
         selectedOutfit = Outfit.Current;
-        doExcludeNewEEs = settings.ShouldExcludeNewEEs;
+        isWindowOpen = false;
     }
     static void OnShowGUI(UnityModManager.ModEntry modEntry) {
-        doExcludeNewEEs = false;
+         isWindowOpen = true;
     }
     static void OnGUI(UnityModManager.ModEntry modEntry) {
         if (Event.current.type == EventType.Layout && (error != null || shouldResetError)) {
@@ -785,7 +786,7 @@ static class Main {
             try {
                 var uniqueId = __instance.GetComponent<UnitEntityView>()?.Data?.UniqueId ?? null;
                 if (uniqueId != null) {
-                    if (doExcludeNewEEs) {
+                    if (doExcludeNewEEs && !isWindowOpen) {
                         EntityPartStorage.perSave.ExcludeByName.TryGetValue(uniqueId, out var tmpExcludes);
                         if (tmpExcludes == null) tmpExcludes = new();
 

--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -39,7 +39,7 @@ static class Main {
     internal static Harmony HarmonyInstance;
     internal static UnityModManager.ModEntry.ModLogger log;
     internal static bool isInRoom = false;
-    internal static bool excludeNewEE = false;
+    internal static bool doExcludeNewEEs = false;
     internal static bool excludeNewEESave = false;
     public static Settings settings;
     static bool Load(UnityModManager.ModEntry modEntry) {
@@ -51,14 +51,14 @@ static class Main {
         modEntry.OnGUI = OnGUI;
         modEntry.OnHideGUI = OnHideGUI;
         modEntry.OnSaveGUI = OnSaveGUI;
+        modEntry.OnShowGUI = OnShowGUI;
         settings = Settings.Load<Settings>(modEntry);
-        excludeNewEESave = settings.ExcludeNewEEs;
+        excludeNewEESave = settings.ShouldExcludeNewEEs;
         HarmonyInstance = new Harmony(modEntry.Info.Id);
         HarmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
         return true;
     }
     static void OnSaveGUI(ModEntry modEntry) {
-        settings.ExcludeNewEEs = excludeNewEESave;
         settings.Save(modEntry);
     }
 
@@ -98,7 +98,7 @@ static class Main {
     internal static int colorPicker3col = 0;
     internal static string colorPickerItem = "";
     internal static Browser<(string, string), (string, string)> includeBrowser = new(true);
-    internal static Browser<Texture2D, Texture2D> rampOverrideBrowser = new(true);  
+    internal static Browser<Texture2D, Texture2D> rampOverrideBrowser = new(true);
     static void OnHideGUI(UnityModManager.ModEntry modEntry) {
         openedGuide = false;
         openedExclude = false;
@@ -108,8 +108,11 @@ static class Main {
         openedColorSection = false;
         colorPickerItem = "";
         selectedOutfit = Outfit.Current;
-        excludeNewEE = excludeNewEESave;
+        doExcludeNewEEs = settings.ShouldExcludeNewEEs;
         settings.Save(modEntry);
+    }
+    static void OnShowGUI(UnityModManager.ModEntry modEntry) {
+        doExcludeNewEEs = false;
     }
     static void OnGUI(UnityModManager.ModEntry modEntry) {
         if (Event.current.type == EventType.Layout && (error != null || shouldResetError)) {
@@ -310,10 +313,6 @@ static class Main {
                     }
 
                     DrawDiv();
-                    excludeNewEESave = GUILayout.Toggle(excludeNewEESave, "Automatically exclude new items on all characters");
-                    excludeNewEE = false; //disable while gui is open
-
-                    DrawDiv();
                     shouldOpenColorSection = GUILayout.Toggle(shouldOpenColorSection, "Show Color Section", GUILayout.ExpandWidth(false));
                     if (Event.current.type == EventType.Layout) {
                         openedColorSection = shouldOpenColorSection;
@@ -447,6 +446,9 @@ static class Main {
                             }
                         }
                     }
+
+                    DrawDiv();
+                    settings.ShouldExcludeNewEEs = GUILayout.Toggle(settings.ShouldExcludeNewEEs, "Automatically exclude new items on all characters");
                 } else {
                     GUILayout.Label("Load a save first!", GUILayout.ExpandWidth(false));
                 }
@@ -515,7 +517,7 @@ static class Main {
         }
     }
     public static void ColorPickerGrid(ref CustomColorTex customColors, ref int customColorIndex, ref int height, ref int width) {
-        bool changedSize = false; 
+        bool changedSize = false;
         using (new GUILayout.HorizontalScope()) {
             GUILayout.Label("Texture Height: ", GUILayout.ExpandWidth(false));
             changedSize |= IntTextField(ref height, GUILayout.MinWidth(60), GUILayout.ExpandWidth(false));
@@ -688,7 +690,7 @@ static class Main {
         internal static string currentUID;
         internal static (CustomColorTex, CustomColorTex, CustomColorTex) customOverride = (null, null, null);
         [HarmonyPrefix]
-        private static void RepaintRextures(EquipmentEntity __instance, EquipmentEntity.PaintedTextures paintedTextures, ref int primaryRampIndex,ref int secondaryRampIndex) {
+        private static void RepaintRextures(EquipmentEntity __instance, EquipmentEntity.PaintedTextures paintedTextures, ref int primaryRampIndex, ref int secondaryRampIndex) {
             customOverride = (null, null, null);
             if (currentUID == null) {
                 log.Log(new System.Diagnostics.StackTrace().ToString());
@@ -785,16 +787,13 @@ static class Main {
         private static bool AddEquipmentEntity(Character __instance, EquipmentEntity ee) {
             try {
                 var uniqueId = __instance.GetComponent<UnitEntityView>()?.Data?.UniqueId ?? null;
-                if (uniqueId != null)
-                {
-                    if (excludeNewEE)
-                    {
+                if (uniqueId != null) {
+                    if (doExcludeNewEEs) {
                         EntityPartStorage.perSave.ExcludeByName.TryGetValue(uniqueId, out var tmpExcludes);
                         if (tmpExcludes == null) tmpExcludes = new();
 
                         cachedLinks.TryGetValue(uniqueId, out var defaultClothes);
-                        if (!(defaultClothes?.Contains(ee) ?? false))
-                        {
+                        if (!(defaultClothes?.Contains(ee) ?? false)) {
                             tmpExcludes.Add(ee.name);
                             EntityPartStorage.perSave.ExcludeByName[uniqueId] = tmpExcludes;
                             EntityPartStorage.SavePerSaveSettings(false);
@@ -802,8 +801,7 @@ static class Main {
                     }
                     EntityPartStorage.perSave.AddClothes.TryGetValue(uniqueId, out var ids);
                     EntityPartStorage.perSave.NakedFlag.TryGetValue(uniqueId, out var nakedFlag);
-                    if (ids?.Count > 0 || nakedFlag)
-                    { 
+                    if (ids?.Count > 0 || nakedFlag) {
                         cachedLinks.TryGetValue(uniqueId, out var defaultClothes);
                         if (defaultClothes?.Contains(ee) ?? false) return false;
                     }
@@ -888,22 +886,18 @@ static class Main {
 
 
     [HarmonyPatch(typeof(CharacterDollRoom), nameof(CharacterDollRoom.Show))]
-    public static class setEEFlagOn
-    {
+    public static class setEEFlagOn {
         [HarmonyPrefix]
-        public static void Show()
-        {
-            excludeNewEE = excludeNewEESave;
+        public static void Show() {
+            doExcludeNewEEs = settings.ShouldExcludeNewEEs;
         }
     }
 
     [HarmonyPatch(typeof(CharacterDollRoom), nameof(CharacterDollRoom.Hide))]
-    public static class setEFlagOff
-    {
+    public static class setEFlagOff {
         [HarmonyPrefix]
-        private static void Hide()
-        {
-            excludeNewEE = false;
+        private static void Hide() {
+            doExcludeNewEEs = false;
         }
     }
 

--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -40,7 +40,6 @@ static class Main {
     internal static UnityModManager.ModEntry.ModLogger log;
     internal static bool isInRoom = false;
     internal static bool doExcludeNewEEs = false;
-    internal static bool excludeNewEESave = false;
     public static Settings settings;
     static bool Load(UnityModManager.ModEntry modEntry) {
         log = modEntry.Logger;

--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -109,7 +109,6 @@ static class Main {
         colorPickerItem = "";
         selectedOutfit = Outfit.Current;
         doExcludeNewEEs = settings.ShouldExcludeNewEEs;
-        settings.Save(modEntry);
     }
     static void OnShowGUI(UnityModManager.ModEntry modEntry) {
         doExcludeNewEEs = false;

--- a/ReDress/Main.cs
+++ b/ReDress/Main.cs
@@ -40,7 +40,6 @@ static class Main {
     internal static UnityModManager.ModEntry.ModLogger log;
     internal static bool isInRoom = false;
     internal static bool doExcludeNewEEs = false;
-    internal static bool isWindowOpen = false;
     public static Settings settings;
     static bool Load(UnityModManager.ModEntry modEntry) {
         log = modEntry.Logger;
@@ -51,7 +50,6 @@ static class Main {
         modEntry.OnGUI = OnGUI;
         modEntry.OnHideGUI = OnHideGUI;
         modEntry.OnSaveGUI = OnSaveGUI;
-        modEntry.OnShowGUI = OnShowGUI;
         settings = Settings.Load<Settings>(modEntry);
         HarmonyInstance = new Harmony(modEntry.Info.Id);
         HarmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
@@ -107,11 +105,8 @@ static class Main {
         openedColorSection = false;
         colorPickerItem = "";
         selectedOutfit = Outfit.Current;
-        isWindowOpen = false;
     }
-    static void OnShowGUI(UnityModManager.ModEntry modEntry) {
-         isWindowOpen = true;
-    }
+
     static void OnGUI(UnityModManager.ModEntry modEntry) {
         if (Event.current.type == EventType.Layout && (error != null || shouldResetError)) {
             if (!shouldResetError) {
@@ -786,7 +781,7 @@ static class Main {
             try {
                 var uniqueId = __instance.GetComponent<UnitEntityView>()?.Data?.UniqueId ?? null;
                 if (uniqueId != null) {
-                    if (doExcludeNewEEs && !isWindowOpen) {
+                    if (doExcludeNewEEs) {
                         EntityPartStorage.perSave.ExcludeByName.TryGetValue(uniqueId, out var tmpExcludes);
                         if (tmpExcludes == null) tmpExcludes = new();
 

--- a/ReDress/Settings.cs
+++ b/ReDress/Settings.cs
@@ -10,6 +10,7 @@ namespace ReDress {
     public class Settings : UnityModManager.ModSettings {
         public string CachedVersion = "";
         public List<(string, string)> AssetIds = new();
+        public bool ExcludeNewEEs = false;
         public override void Save(UnityModManager.ModEntry modEntry) {
             Save(this, modEntry);
         }

--- a/ReDress/Settings.cs
+++ b/ReDress/Settings.cs
@@ -10,7 +10,7 @@ namespace ReDress {
     public class Settings : UnityModManager.ModSettings {
         public string CachedVersion = "";
         public List<(string, string)> AssetIds = new();
-        public bool ExcludeNewEEs = false;
+        public bool ShouldExcludeNewEEs = false;
         public override void Save(UnityModManager.ModEntry modEntry) {
             Save(this, modEntry);
         }


### PR DESCRIPTION
If gui is closed and dollroom is open, adding a piece of equipment will add it automatically to the exclude list while the toggle is set, preventing unwanted changes to custom outfits. If gui is open regardless of toggle, then include/exclude behavior should be as normal. 